### PR TITLE
Use unarchive module

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: "Daemonize for Unix-like operating systems"
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
-  min_ansible_version: 1.4
+  min_ansible_version: 2.0
   platforms:
   - name: EL
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,10 @@
 ---
-- name: Download daemonize archive.
-  get_url:
-    url: "https://github.com/bmc/daemonize/archive/release-{{ daemonize_version }}.tar.gz"
-    dest: "{{ workspace }}/daemonize-{{ daemonize_version }}.tar.gz"
-
-- name: Expand daemonize archive.
-  command: >
-    tar -zxf {{ workspace }}/daemonize-{{ daemonize_version }}.tar.gz
-    chdir={{ workspace }}
-    creates={{ workspace }}/daemonize-release-{{ daemonize_version }}/INSTALL
+- name: Download and expand daemonize archive.
+  unarchive:
+    src: "https://github.com/bmc/daemonize/archive/release-{{ daemonize_version }}.tar.gz"
+    dest: "{{ workspace }}"
+    creates: "{{ workspace }}/daemonize-release-{{ daemonize_version }}/INSTALL"
+    copy: no
 
 - name: Check if daemonize is installed.
   command: which daemonize


### PR DESCRIPTION
Fixes https://github.com/geerlingguy/ansible-role-daemonize/issues/2.

I bumped the dependency to 2.0 as it's now uses unarchives [remote url](http://docs.ansible.com/ansible/unarchive_module.html) feature as well. If we left the old download task it would support ansible 1.6+
