### PR TITLE
Change built in unarchive to shell command

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,11 +5,7 @@
     dest: "{{ workspace }}/daemonize-{{ daemonize_version }}.tar.gz"
 
 - name: Expand daemonize archive.
-  unarchive:
-    src: "{{ workspace }}/daemonize-{{ daemonize_version }}.tar.gz"
-    dest: "{{ workspace }}"
-    creates: "{{ workspace }}/daemonize-release-{{ daemonize_version }}/INSTALL"
-    copy: no
+  shell: tar -xzvf {{ workspace }}/daemonize-{{ daemonize_version }}.tar.gz -C {{ workspace }}
 
 - name: Check if daemonize is installed.
   command: which daemonize


### PR DESCRIPTION
I changed the built in ansible unarchive command to a shell script command because it didn't unarchive the tar.gz correctly under CentOS 7. This is a problem with the unarchive ansible command because under EL repos doesn't work correctly. 
