### PR TITLE
Let the build task survive 'check' mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible-base yamllint ansible-lint
+        run: pip3 install yamllint ansible-lint
 
       - name: Lint code.
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install yamllint ansible-lint
+        run: pip3 install ansible-base yamllint ansible-lint
 
       - name: Lint code.
         run: |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,7 @@
     {{ item }}
     chdir={{ workspace }}/daemonize-release-{{ daemonize_version }}
   when: daemonize_installed.rc != 0
+  ignore_errors: "{{ ansible_check_mode }}"
   with_items:
     - "./configure --prefix={{ daemonize_install_path }}"
     - make


### PR DESCRIPTION
The registered variable's "rc" property doesn't exist in check mode, causing the task to fail. This fix just lets the playbook continue past the error in check mode.